### PR TITLE
Remove Resulting PFN log

### DIFF
--- a/src/XrdCmsTfc.cc
+++ b/src/XrdCmsTfc.cc
@@ -314,7 +314,6 @@ XrdCmsTfc::TrivialFileCatalog::lfn2pfn(const char *lfn, char *buff, int blen)
         tmpLfn = applyRules(m_directRules, *protocol, m_destination, true, tmpLfn);
         if (!tmpLfn.empty()) {
             strncpy(buff, tmpLfn.c_str(), blen);
-            eDest->Say("Resulting PFN: ", buff);
             return 0;
         }
     }   


### PR DESCRIPTION
i guess the increasing logging reported by the DPM admins comes from a higher traffic on AAA.
if this is not a problem it would be nice to remove this log line