### PR TITLE
Adding requirements on major version of XRootD (software-4137)

### DIFF
--- a/spec/xrootd-cmstfc.spec
+++ b/spec/xrootd-cmstfc.spec
@@ -12,10 +12,11 @@ Source0: %{name}.tar.gz
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 %define xrootd_current_major 4
+%define xrootd_current_minor 12
 %define xrootd_next_major 5
 
-BuildRequires: xrootd-devel >= 1:%{xrootd_current_major}.0.0-1
-BuildRequires: xrootd-devel <  1:%{xrootd_next_major}.0.0-1
+BuildRequires: xrootd-devel >= 1:%{xrootd_current_major}
+BuildRequires: xrootd-devel <  1:%{xrootd_next_major}
 BuildRequires: pcre-devel
 BuildRequires: xerces-c-devel
 BuildRequires: cmake
@@ -25,7 +26,7 @@ Requires: /usr/bin/xrootd pcre xerces-c
 #%if 0%{?rhel} < 7
 #Requires: xrootd4 >= 1:4.1.0
 #%else
-Requires: xrootd >= 1:%{xrootd_current_major}.0.0-1
+Requires: xrootd >= 1:%{xrootd_current_major}.%{xrootd_current_minor}
 Requires: xrootd <  1:%{xrootd_next_major}.0.0-1
 #%endif
 

--- a/spec/xrootd-cmstfc.spec
+++ b/spec/xrootd-cmstfc.spec
@@ -23,12 +23,8 @@ BuildRequires: cmake
 
 Requires: /usr/bin/xrootd pcre xerces-c
 
-#%if 0%{?rhel} < 7
-#Requires: xrootd4 >= 1:4.1.0
-#%else
 Requires: xrootd >= 1:%{xrootd_current_major}.%{xrootd_current_minor}
 Requires: xrootd <  1:%{xrootd_next_major}.0.0-1
-#%endif
 
 %package devel
 Summary: Development headers and libraries for Xrootd CMSTFC plugin

--- a/spec/xrootd-cmstfc.spec
+++ b/spec/xrootd-cmstfc.spec
@@ -14,8 +14,8 @@ BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 %define xrootd_current_major 4
 %define xrootd_next_major 5
 
-BuildRequires: xrootd-devel >= 1:%{xrootd_current_major}.0.0-0
-BuildRequires: xrootd-devel <  1:%{xrootd_next_major}.0.0-0
+BuildRequires: xrootd-devel >= 1:%{xrootd_current_major}.0.0-1
+BuildRequires: xrootd-devel <  1:%{xrootd_next_major}.0.0-1
 BuildRequires: pcre-devel
 BuildRequires: xerces-c-devel
 BuildRequires: cmake
@@ -25,8 +25,8 @@ Requires: /usr/bin/xrootd pcre xerces-c
 #%if 0%{?rhel} < 7
 #Requires: xrootd4 >= 1:4.1.0
 #%else
-Requires: xrootd >= 1:%{xrootd_current_major}.0.0-0
-Requires: xrootd <  1:%{xrootd_next_major}.0.0-0
+Requires: xrootd >= 1:%{xrootd_current_major}.0.0-1
+Requires: xrootd <  1:%{xrootd_next_major}.0.0-1
 #%endif
 
 %package devel

--- a/spec/xrootd-cmstfc.spec
+++ b/spec/xrootd-cmstfc.spec
@@ -41,16 +41,14 @@ Group: System Environment/Development
 %{summary}
 
 %prep
-%setup -q -c -n %{name}-%{version}
+%setup -q
 
 %build
-cd %{name}-%{version}
 %cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_LIBDIR=%{_lib} .
 make VERBOSE=1 %{?_smp_mflags}
 
 %install
 rm -rf $RPM_BUILD_ROOT
-cd %{name}-%{version}
 make install DESTDIR=$RPM_BUILD_ROOT
 
 %clean

--- a/spec/xrootd-cmstfc.spec
+++ b/spec/xrootd-cmstfc.spec
@@ -1,7 +1,6 @@
-
 Name: xrootd-cmstfc
-Version: 1.5.1
-Release: 3%{?dist}
+Version: 1.5.2
+Release: 6%{?dist}
 Summary: CMS TFC plugin for xrootd
 
 Group: System Environment/Daemons
@@ -11,9 +10,28 @@ URL: https://github.com/bbockelm/xrootd-cmstfc
 # git-archive master | gzip -7 > ~/rpmbuild/SOURCES/xrootd-lcmaps.tar.gz
 Source0: %{name}.tar.gz
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
-BuildRequires: xrootd-libs-devel xerces-c-devel pcre-devel
+
+%define xrootd_current_major 4
+%define xrootd_next_major 5
+
+BuildRequires: xrootd-devel >= 1:%{xrootd_current_major}.0.0-1
+BuildRequires: xrootd-devel <  1:%{xrootd_next_major}.0.0-1
+BuildRequires: pcre-devel
+
+BuildRequires: xerces-c-devel
+
 BuildRequires: cmake
+#BuildRequires: xrootd-compat-libs
+
 Requires: /usr/bin/xrootd pcre xerces-c
+#Requires: xrootd-compat-libs
+
+#%if 0%{?rhel} < 7
+#Requires: xrootd4 >= 1:4.1.0
+#%else
+Requires: xrootd >= 1:%{xrootd_current_major}.0.0-1
+Requires: xrootd <  1:%{xrootd_next_major}.0.0-1
+#%endif
 
 %package devel
 Summary: Development headers and libraries for Xrootd CMSTFC plugin
@@ -29,12 +47,13 @@ Group: System Environment/Development
 %setup -q -c -n %{name}-%{version}
 
 %build
-
-%cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+cd %{name}-%{version}
+%cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_LIBDIR=%{_lib} .
 make VERBOSE=1 %{?_smp_mflags}
 
 %install
 rm -rf $RPM_BUILD_ROOT
+cd %{name}-%{version}
 make install DESTDIR=$RPM_BUILD_ROOT
 
 %clean
@@ -50,6 +69,43 @@ rm -rf $RPM_BUILD_ROOT
 %{_includedir}/XrdCmsTfc.hh
 
 %changelog
+* Fri Jun 26 2020 Diego Davila <didavila@ucsd.edu> - 1.5.2-6
+- Adding requirements on major version of XRootD (SOFTWARE-4137)
+
+* Mon Apr 13 2020 Diego Davila <didavila@ucsd.edu> - 1.5.2-5
+- Rebuild against xrootd 5.0.0-rc2 (SOFTWARE-3923)
+
+* Thu Jul 18 2019 Carl Edquist <edquist@cs.wisc.edu> - 1.5.2-4
+- Rebuild against xrootd 4.10.0 (SOFTWARE-3697)
+
+* Wed Apr 24 2019 Carl Edquist <edquist@cs.wisc.edu> - 1.5.2-3
+- Rebuild against xrootd 4.9.1 (SOFTWARE-3678)
+
+* Wed Feb 27 2019 Carl Edquist <edquist@cs.wisc.edu> - 1.5.2-2
+- Rebuild against xrootd 4.9.0 (SOFTWARE-3485)
+
+* Wed Sep 05 2018 Edgar Fajardo <emfajard@ucsd.edu> 1.5.2-1
+- Small change to reduce the logging verbosity of this plugin for the DPM team.
+
+* Tue Aug 08 2017 Brian Lin <blin@cs.wisc.edu> 1.5.1-11%{?dist}
+- Build libraries into the appropriate shared lib arch path
+
+* Mon Feb 23 2015 Edgar Fajardo <emfajard@ucsd.edu> 1.5.1-10%{?dist}
+- Require xrootd (instead of xrootd4) for all builds
+
+* Fri Dec 05 2014 Mátyás Selmeci <matyas@cs.wisc.edu> 1.5.1-9%{?dist}
+- Require xrootd (instead of xrootd4) on EL7
+
+* Mon Jul 14 2014 Edgar Fakardo <efajardo@physics.ucsd.edu> - 1.5.1-8
+- Rebuild against xrootd4 and fixed xrootd4 requirements
+
+* Thu Apr 18 2013 Matyas Selmeci <matyas@cs.wisc.edu> - 1.5.1-6
+- Require and BuildRequire xrootd 3.3.1 explicitly
+
+* Wed Apr 03 2013 Matyas Selmeci <matyas@cs.wisc.edu> - 1.5.1-4
+- Bump to rebuild against xrootd 3.3.1
+- Rename xrootd-libs-devel dependency to match what 3.3.1 calls it
+
 * Thu Nov 29 2012 Brian Bockelman <bbockelm@cse.unl.edu> - 1.5.1-3
 - Move module back into base RPM.
 

--- a/spec/xrootd-cmstfc.spec
+++ b/spec/xrootd-cmstfc.spec
@@ -14,8 +14,8 @@ BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 %define xrootd_current_major 4
 %define xrootd_next_major 5
 
-BuildRequires: xrootd-devel >= 1:%{xrootd_current_major}.0.0-1
-BuildRequires: xrootd-devel <  1:%{xrootd_next_major}.0.0-1
+BuildRequires: xrootd-devel >= 1:%{xrootd_current_major}.0.0-0
+BuildRequires: xrootd-devel <  1:%{xrootd_next_major}.0.0-0
 BuildRequires: pcre-devel
 
 BuildRequires: xerces-c-devel
@@ -29,8 +29,8 @@ Requires: /usr/bin/xrootd pcre xerces-c
 #%if 0%{?rhel} < 7
 #Requires: xrootd4 >= 1:4.1.0
 #%else
-Requires: xrootd >= 1:%{xrootd_current_major}.0.0-1
-Requires: xrootd <  1:%{xrootd_next_major}.0.0-1
+Requires: xrootd >= 1:%{xrootd_current_major}.0.0-0
+Requires: xrootd <  1:%{xrootd_next_major}.0.0-0
 #%endif
 
 %package devel

--- a/spec/xrootd-cmstfc.spec
+++ b/spec/xrootd-cmstfc.spec
@@ -17,14 +17,10 @@ BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires: xrootd-devel >= 1:%{xrootd_current_major}.0.0-0
 BuildRequires: xrootd-devel <  1:%{xrootd_next_major}.0.0-0
 BuildRequires: pcre-devel
-
 BuildRequires: xerces-c-devel
-
 BuildRequires: cmake
-#BuildRequires: xrootd-compat-libs
 
 Requires: /usr/bin/xrootd pcre xerces-c
-#Requires: xrootd-compat-libs
 
 #%if 0%{?rhel} < 7
 #Requires: xrootd4 >= 1:4.1.0


### PR DESCRIPTION
This adds the requirements on the major version of XRootD.
I used as a base the spec file currently used in OSG which adds few other minor changes