### PR TITLE
increasing buffer size at replaceWithRegexp to avoid compilation error

### DIFF
--- a/src/XrdCmsTfc.cc
+++ b/src/XrdCmsTfc.cc
@@ -355,7 +355,7 @@ std::string replaceWithRegexp (const int ovector[OVECCOUNT], const int rc,
 {
     //std::cerr << "InputString:" << inputString << std::endl;
  
-    char buffer[8];
+    char buffer[11];
     std::string result = outputFormat;
     int substring_length;
     int substring_begin;


### PR DESCRIPTION
When trying to build for el8 using koji, it fails with the following error[*]. It goes away when I apply the change in this PR

> src/XrdCmsTfc.cc: In function ‘std::__cxx11::string replaceWithRegexp(const int*, int, std::__cxx11::string, std::__cxx11::string)’:
src/XrdCmsTfc.cc:369:18: error: ‘%i’ directive writing between 1 and 10 bytes into a region of size 8 [-Werror=format-overflow=]
  sprintf(buffer, "%i", i);
                  ^~~~
src/XrdCmsTfc.cc:369:18: note: directive argument in the range [1, 1073741824]
In file included from /usr/include/stdio.h:873,
                 from /usr/include/c++/8/cstdio:42,
                 from /usr/include/c++/8/ext/string_conversions.h:43,
                 from /usr/include/c++/8/bits/basic_string.h:6400,
                 from /usr/include/c++/8/string:52,
                 from src/XrdCmsTfc.cc:11:
/usr/include/bits/stdio2.h:36:34: note: ‘__builtin___sprintf_chk’ output between 2 and 11 bytes into a destination of size 8
   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __bos (__s), __fmt, __va_arg_pack ());
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
